### PR TITLE
Use CORS config to allow credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.mypy_cache

--- a/README.md
+++ b/README.md
@@ -26,16 +26,14 @@ It is inspired by the examples available in [sunilbandla/vue-msal-sample](https:
 	"oauth2AllowImplicitFlow": true,
 ```
 
-3. In `app/src/services/auth.service.js`, enter the Directory (tenant) ID and Application (client) ID for both app registrations.
+3. Make a copy of `app/dotenv.local.template` as `app/.env.local` and fill ID's.
 
-4. In `api/api.py`, enter the Directory (tenant) ID and Application (client) ID for the API app registration.
-
-5. Run the Python server:
+4. Run the Python server:
 
     a. In `api`, install all requirements through `pip install -r requirements.txt`
 
     b. Run the Flask app through `python api.py`.
 
-6. Run a server hosting the frontend:
+5. Run a server hosting the frontend:
 
     a. In `app` run `npm run serve`.

--- a/api/api.py
+++ b/api/api.py
@@ -7,7 +7,11 @@ from pathlib import Path
 
 
 app = Flask(__name__)
-CORS(app)
+CORS(
+    app,
+    origins = ["http://localhost:8080"],
+    supports_credentials = True,  # does not appear to be needed?
+)
 
 
 dotenv.load_dotenv(Path(__file__).parent / '../app/.env.local')
@@ -19,27 +23,21 @@ auth = FlaskAzureOauth()
 auth.init_app(app)
 
 
-def cors(response):
-    response.headers.add("Access-Control-Allow-Origin", "http://localhost:8080")
-    response.headers.add("Access-Control-Allow-Credentials", "true")
-    return response
-
-
 @app.route("/unprotected")
 def unprotected():
-    return cors(jsonify({"success": True}))
+    return jsonify({"success": True})
 
 
 @app.route("/protected")
 @auth()
 def protected():
-    return cors(jsonify({"success": True}))
+    return jsonify({"success": True})
 
 
 @app.route("/protected-with-role")
 @auth("Write.All")
 def protected_with_scope():
-    return cors(jsonify({"success": True}))
+    return jsonify({"success": True})
 
 
 app.run(debug=True)

--- a/api/api.py
+++ b/api/api.py
@@ -1,13 +1,19 @@
 from flask import Flask, jsonify
 from flask_cors import CORS
-
 from flask_azure_oauth import FlaskAzureOauth
+import dotenv
+import os
+from pathlib import Path
+
 
 app = Flask(__name__)
 CORS(app)
 
-app.config["AZURE_OAUTH_APPLICATION_ID"] = "{Application (client) ID for backend app registration}"
-app.config["AZURE_OAUTH_TENANCY"] = "{Directory (tenant) ID}"
+
+dotenv.load_dotenv(Path(__file__).parent / '../app/.env.local')
+app.config["AZURE_OAUTH_APPLICATION_ID"] = os.environ["VUE_APP_AZURE_OAUTH_BACKEND_APPLICATION_ID"]
+app.config["AZURE_OAUTH_TENANCY"] = os.environ["VUE_APP_AZURE_OAUTH_TENANCY"]
+
 
 auth = FlaskAzureOauth()
 auth.init_app(app)

--- a/api/api.py
+++ b/api/api.py
@@ -1,4 +1,4 @@
-from flask import Flask, jsonify
+from flask import Flask
 from flask_cors import CORS
 from flask_azure_oauth import FlaskAzureOauth
 import dotenv
@@ -7,11 +7,7 @@ from pathlib import Path
 
 
 app = Flask(__name__)
-CORS(
-    app,
-    origins = ["http://localhost:8080"],
-    supports_credentials = True,  # does not appear to be needed?
-)
+CORS(app, origins = ["http://localhost:8080"])
 
 
 dotenv.load_dotenv(Path(__file__).parent / '../app/.env.local')
@@ -25,19 +21,19 @@ auth.init_app(app)
 
 @app.route("/unprotected")
 def unprotected():
-    return jsonify({"success": True})
+    return {"success": True}
 
 
 @app.route("/protected")
 @auth()
 def protected():
-    return jsonify({"success": True})
+    return {"success": True}
 
 
 @app.route("/protected-with-role")
 @auth("Write.All")
 def protected_with_scope():
-    return jsonify({"success": True})
+    return {"success": True}
 
 
 app.run(debug=True)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,3 +1,4 @@
 flask
 flask_cors
 flask_azure_oauth
+python-dotenv

--- a/app/dotenv.local.template
+++ b/app/dotenv.local.template
@@ -1,0 +1,9 @@
+# Template for .env.local -- duplicate and fill values locally
+# This file is read by both frontend and backend
+#
+# Format: https://cli.vuejs.org/guide/mode-and-env.html#environment-variables
+# Note that backend only looks for env.local
+
+VUE_APP_AZURE_OAUTH_BACKEND_APPLICATION_ID=####
+VUE_APP_AZURE_OAUTH_FRONTEND_APPLICATION_ID=####
+VUE_APP_AZURE_OAUTH_TENANCY=####

--- a/app/src/services/auth.service.js
+++ b/app/src/services/auth.service.js
@@ -4,8 +4,8 @@ export default class AuthService {
   constructor() {
     this.applicationConfig = {
       auth: {
-        clientId: '{Application (client) ID for frontend app registration}',
-        authority: "https://login.microsoftonline.com/{Directory (tenant) ID}"
+        clientId: process.env.VUE_APP_AZURE_OAUTH_FRONTEND_APPLICATION_ID,
+        authority: "https://login.microsoftonline.com/"+process.env.VUE_APP_AZURE_OAUTH_TENANCY,
       },
       cache: {
         cacheLocation: "localStorage",
@@ -13,7 +13,8 @@ export default class AuthService {
       }
     };
     this.requestObj = {
-      scopes: ['api://{Application (client) ID for backend app registration}/Read.All']
+      scopes: ['api://'+process.env.VUE_APP_AZURE_OAUTH_BACKEND_APPLICATION_ID+'/Read.All']
+
     }
     this.app = new Msal.UserAgentApplication(this.applicationConfig);
   }


### PR DESCRIPTION
As we discussed, I tried using CORS config instead of the manual `Access-Control-Allow-Credentials`-header. I also moved all the ID's to a `.env.local`-file because it took my en embarrassing amount of time to get them all inserted to run this. Feel free to cherry-pick.
Note that I added a dotenv dependency to `requirements.txt`.